### PR TITLE
Remove reference to KSPUtil.dll

### DIFF
--- a/LandingHeight/LandingHeight.csproj
+++ b/LandingHeight/LandingHeight.csproj
@@ -34,10 +34,6 @@
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\1.1 Dev\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="KSPUtil">
-      <HintPath>..\..\..\1.1 Dev\KSP_x64_Data\Managed\KSPUtil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Remove reference to KSPUtil.dll which makes the project compile on KSP 1.2 pre-release.
